### PR TITLE
fix(compose): correct Postgres 18 volume mount path for with-db profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ DATABASE_URL=postgresql://postgres:postgres@postgres:5432/remote_coding_agent
 
 Database will be created automatically when you start with `docker compose --profile with-db`.
 
+If you previously started the old compose config, reset the local DB volume once with `docker compose --profile with-db down -v` before bringing it back up.
+
 </details>
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # Postgres 18+ expects the volume at /var/lib/postgresql to manage its own versioned directories.
+      - postgres_data:/var/lib/postgresql
       - ./migrations:/docker-entrypoint-initdb.d
     ports:
       - "${POSTGRES_PORT:-5432}:5432"


### PR DESCRIPTION
* **Problem**: `docker compose --profile with-db up` fails with Postgres 18+ complaining about an "unused mount/volume" at `/var/lib/postgresql/data`.
* **Root cause**: compose mounts the named volume at the legacy path (`/var/lib/postgresql/data`), but Postgres 18+ uses a major-version-specific data layout and expects a single mount at `/var/lib/postgresql`.
* **Fix**: mount `postgres_data` at `/var/lib/postgresql` (no `/data`).
* **Test** (fresh volume recommended):  
  `docker compose --profile with-db down -v; docker compose --profile with-db up -d --build`  
  Result: `postgres` becomes healthy and `app-with-db` starts successfully.
> Windows note: `;` works in PowerShell. On Linux/macOS use `&&` to chain commands.
